### PR TITLE
Add "Notion-Version" header required

### DIFF
--- a/src/Client/NotionClient.php
+++ b/src/Client/NotionClient.php
@@ -22,7 +22,7 @@ class NotionClient
         $this->client = $restClient ?: new Client([
             'base_uri' => $baseUri,
             'timeout' => $timeout,
-            'headers' => ['Authorization' => "Bearer {$accessToken}"],
+            'headers' => ['Authorization' => "Bearer {$accessToken}",'Notion-Version' => '2021-05-13'],
         ]);
     }
 


### PR DESCRIPTION
The Notion API has recommended using an explicit version to every HTTP request, using the Notion-Version header. For integrations created after June 1, 2021 an explicit version on every request will become required. After July 1, 2021, integrations created before June 1, 2021 will also have the same requirement. Today, the most recent version is "2021-05-13".
https://developers.notion.com/changelog/unversioned-requests-no-longer-accepted